### PR TITLE
chore!: remove Context.clear() and Context.cleanup()

### DIFF
--- a/scenario/context.py
+++ b/scenario/context.py
@@ -318,33 +318,6 @@ class Context:
         storage_root.mkdir(parents=True, exist_ok=True)
         return storage_root
 
-    def clear(self):
-        """Deprecated.
-
-        Use cleanup instead.
-        """
-        logger.warning(
-            "Context.clear() is deprecated and will be nuked in v6. "
-            "Use Context.cleanup() instead.",
-        )
-        self.cleanup()
-
-    def cleanup(self):
-        """Cleanup side effects histories and reset the simulated filesystem state."""
-        self.juju_log = []
-        self.app_status_history = []
-        self.unit_status_history = []
-        self.workload_version_history = []
-        self.emitted_events = []
-        self.requested_storages = {}
-        self._action_logs = []
-        self._action_results = None
-        self._action_failure = None
-        self._output_state = None
-
-        self._tmp.cleanup()
-        self._tmp = tempfile.TemporaryDirectory()
-
     def _record_status(self, state: "State", is_app: bool):
         """Record the previous status before a status change."""
         if is_app:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -51,17 +51,6 @@ def test_run_action():
     assert a.id == expected_id
 
 
-def test_clear():
-    ctx = Context(MyCharm, meta={"name": "foo"})
-    state = State()
-
-    ctx.run("start", state)
-    assert ctx.emitted_events
-
-    ctx.clear()
-    assert not ctx.emitted_events  # and others...
-
-
 @pytest.mark.parametrize("app_name", ("foo", "bar", "george"))
 @pytest.mark.parametrize("unit_id", (1, 2, 42))
 def test_app_name(app_name, unit_id):


### PR DESCRIPTION
Removes `Context.cleanup()`. That method allows re-use of a Context (in particular, forgetting the histories), but in general we'd rather promote creating a fresh `Context` to align with other scenario usage.

`Context.clear()` is a deprecated alias for cleanup, so remove it as well.